### PR TITLE
Adjust the download references to work with S3 storage

### DIFF
--- a/subworkflows/download_references.nf
+++ b/subworkflows/download_references.nf
@@ -6,7 +6,7 @@ workflow DOWNLOAD_REFERENCES {
     take:
     biome
     bwamem2_mode
-    
+
 
     main:
     dram_dbs = Channel.empty()
@@ -34,9 +34,13 @@ workflow DOWNLOAD_REFERENCES {
 
     // Human PhiX genome used to decontaminate the reads
     human_phix_index_dir = file("${params.decontamination_indexes}/human_phix*")
-    human_phix_index = human_phix_index_dir.size() > 0
-        ? human_phix_index_dir
-        : DOWNLOAD_HUMAN_PHIX_BWAMEM2_INDEX().out.human_phix_index.first()
+    human_phix_index = channel.empty()
+
+    if ( human_phix_index_dir.size() > 0 ) {
+        human_phix_index = channel.from( human_phix_index_dir )
+    } else {
+        human_phix_index = DOWNLOAD_HUMAN_PHIX_BWAMEM2_INDEX().human_phix_index.first()
+    }
 
     // Check if all required files exist for the biome
 
@@ -57,7 +61,7 @@ workflow DOWNLOAD_REFERENCES {
         biome_bwa_db = bwamem2_mode ? DOWNLOAD_MGNIFY_GENOMES_REFERENCE_DBS.out.bwamem2_index.collect() : Channel.empty()
     }
 
-    human_phix_index_ch = channel.from( human_phix_index ).collect()
+    human_phix_index_ch = human_phix_index.collect()
         .map { db_files ->
             [[id: "human_phix"], db_files]
         }

--- a/workflows/biosiftr.nf
+++ b/workflows/biosiftr.nf
@@ -215,8 +215,8 @@ workflow BIOSIFTR {
 
         // Mapping reads and filtering positive genomes according with mapping coverage threshold
         POSTPROC_SOURMASHTAXO.out.sm_taxo
-            .map{ meta, taxo_file -> 
-                species_richness = taxo_file.countLines()
+            .map{ meta, taxo_file ->
+                def species_richness = taxo_file.countLines()
                 return tuple(meta, species_richness)
             }.set {
                 species_richness_ch


### PR DESCRIPTION
I've adjusted the download human reference.. it wasn't working with an S3 bucket.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/biosiftr/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
