### PR TITLE
I've changed how the DRAM db is used in distill

### DIFF
--- a/conf/container_native.config
+++ b/conf/container_native.config
@@ -1,0 +1,44 @@
+/**
+ * Container-native execution profile for cloud platforms
+ *
+ * This profile addresses a compatibility issue with DRAM_DISTILL when running on
+ * container-native executors (Kubernetes, Google Cloud Batch, AWS Batch, etc.).
+ *
+ * The issue is that containerOptions used to mount the dram databases and config file are not
+ * supported.
+ *
+ * The solution: This beforeScript dynamically generates a minimal DRAM configuration
+ */
+profiles {
+    container_native {
+        process {
+            withName: 'EBIMETAGENOMICS_BIOSIFTR:BIOSIFTR:DRAM_DISTILL' {
+                beforeScript = {
+                    """
+                    echo '{
+                        "description_db": "None",
+                        "kegg": null,
+                        "kofam": null,
+                        "kofam_ko_list": null,
+                        "uniref": null,
+                        "pfam": null,
+                        "pfam_hmm_dat": null,
+                        "dbcan": null,
+                        "dbcan_fam_activities": null,
+                        "viral": null,
+                        "peptidase": null,
+                        "vogdb": null,
+                        "vog_annotations": null,
+                        "genome_summary_form": "${dram_reference_db_folder}/genome_summary_form.tsv",
+                        "module_step_form": "${dram_reference_db_folder}/module_step_form.tsv",
+                        "etc_module_database": "${dram_reference_db_folder}/etc_module_database.tsv",
+                        "function_heatmap_form": "${dram_reference_db_folder}/function_heatmap_form.tsv",
+                        "amg_database": "${dram_reference_db_folder}/amg_database.tsv"
+                    }' > /usr/local/lib/python3.10/site-packages/mag_annotator/CONFIG
+                    """
+                }
+                containerOptions = ""
+            }
+        }
+    }
+}

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -122,6 +122,19 @@ process {
     withName: DRAM_DISTILL {
         cpus   = 1
         memory = { 24.GB * task.attempt }
+
+        containerOptions = {
+            def arg = "--volume"
+            if (workflow.containerEngine == 'singularity' || workflow.containerEngine == 'apptainer') {
+                arg = "--bind"
+            }
+            def mounts = [
+                "${task.workDir}/${dram_reference_db_folder}/:/data/",
+                "${task.workDir}/${dram_reference_db_folder}/DRAM_CONFIG.json:/usr/local/lib/python3.10/site-packages/mag_annotator/CONFIG",
+            ]
+            return "${arg} " + mounts.join(" ${arg} ")
+        }
+
         publishDir = [
             [
                 path: { "${params.outdir}/dram_results" },

--- a/modules/local/download_mgnify_genomes_reference_dbs.nf
+++ b/modules/local/download_mgnify_genomes_reference_dbs.nf
@@ -20,19 +20,13 @@ process DOWNLOAD_MGNIFY_GENOMES_REFERENCE_DBS {
     def biome_name = matcher[0][1]
     def biome_version = matcher[0][2] ? matcher[0][2].substring(1) : null
 
-    if (biome_version) {
-        biome_version = biome_version.replace('-', '.')
-    } else {
-        exit("Error the biome version of ${biome} can't be parsed.")
-    }
-
     // MGnify genomes catalogue data //
     // Example: https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/honeybee-gut/v1.0.1/
     def biome_catalogue_ftp = "ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/${biome_name}/${biome_version}"
 
     // Shallow mapping specific //
     // This FTP path contains the MGnify Genomes catalogue processed annotations, ready to be used with this pipeline
-    def ftp_base = "ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/pipelines/references/mgnify_genomes/${biome_name}_reps/${biome_version}/"
+    def ftp_base = "ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/pipelines/references/mgnify_genomes/${biome_name}_reps/${biome_version}"
 
     def functions_ftp = "${ftp_base}/pangenome_functional_profiles.tar.gz"
     def kegg_ftp = "${ftp_base}/kegg_completeness.tar.gz"
@@ -40,7 +34,7 @@ process DOWNLOAD_MGNIFY_GENOMES_REFERENCE_DBS {
     def reps_bwamem2_index_ftp = "${ftp_base}/reps_bwamem2.tar.gz"
 
     """
-    if [[ "${download_bwamem2}" == 'True' ]];
+    if [[ "${download_bwamem2}" == 'true' ]];
     then
         # Downloading the host genome #
         mkdir -p bwamem2_index/

--- a/modules/local/download_mgnify_genomes_reference_dbs.nf
+++ b/modules/local/download_mgnify_genomes_reference_dbs.nf
@@ -20,6 +20,12 @@ process DOWNLOAD_MGNIFY_GENOMES_REFERENCE_DBS {
     def biome_name = matcher[0][1]
     def biome_version = matcher[0][2] ? matcher[0][2].substring(1) : null
 
+    if (biome_version) {
+        biome_version = biome_version.replace('-', '.')
+    } else {
+        exit("Error the biome version of ${biome} can't be parsed.")
+    }
+
     // MGnify genomes catalogue data //
     // Example: https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/honeybee-gut/v1.0.1/
     def biome_catalogue_ftp = "ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/${biome_name}/${biome_version}"

--- a/modules/local/dram/distill.nf
+++ b/modules/local/dram/distill.nf
@@ -6,21 +6,21 @@ process DRAM_DISTILL {
         ? 'https://depot.galaxyproject.org/singularity/dram:1.3.5--pyhdfd78af_0'
         : 'quay.io/biocontainers/dram:1.3.5--pyhdfd78af_0'}"
 
-
     containerOptions {
         def arg = "--volume"
         if (workflow.containerEngine == 'singularity' || workflow.containerEngine == 'apptainer') {
             arg = "--bind"
         }
         def mounts = [
-            "${params.reference_dbs}/dram_dbs/:/data/",
-            "${params.reference_dbs}/dram_dbs/DRAM_CONFIG.json:/usr/local/lib/python3.10/site-packages/mag_annotator/CONFIG",
+            "${task.workDir}/${reference_dbs}/dram_dbs/:/data/",
+            "${task.workDir}/${reference_dbs}/dram_dbs/DRAM_CONFIG.json:/usr/local/lib/python3.10/site-packages/mag_annotator/CONFIG",
         ]
         return "${arg} " + mounts.join(" ${arg} ")
     }
 
     input:
     tuple val(meta), path(dram_summary)
+    path(reference_dbs)
     val tool      // sm for sourmash or bwa for bwa-mem2
     val in_type   // species or community
 

--- a/modules/local/dram/distill.nf
+++ b/modules/local/dram/distill.nf
@@ -6,21 +6,9 @@ process DRAM_DISTILL {
         ? 'https://depot.galaxyproject.org/singularity/dram:1.3.5--pyhdfd78af_0'
         : 'quay.io/biocontainers/dram:1.3.5--pyhdfd78af_0'}"
 
-    containerOptions {
-        def arg = "--volume"
-        if (workflow.containerEngine == 'singularity' || workflow.containerEngine == 'apptainer') {
-            arg = "--bind"
-        }
-        def mounts = [
-            "${task.workDir}/${reference_dbs}/dram_dbs/:/data/",
-            "${task.workDir}/${reference_dbs}/dram_dbs/DRAM_CONFIG.json:/usr/local/lib/python3.10/site-packages/mag_annotator/CONFIG",
-        ]
-        return "${arg} " + mounts.join(" ${arg} ")
-    }
-
     input:
     tuple val(meta), path(dram_summary)
-    path(reference_dbs)
+    path(dram_reference_db_folder)
     val tool      // sm for sourmash or bwa for bwa-mem2
     val in_type   // species or community
 

--- a/modules/local/kegg/species.nf
+++ b/modules/local/kegg/species.nf
@@ -11,7 +11,6 @@ process KEGG_SPECIES {
     val(tool)
     val(mode)
     path(kegg_db)
-    
 
     output:
     tuple val(meta), path("*.tsv"), emit: spec_kegg_comp
@@ -41,6 +40,7 @@ process KEGG_SPECIES {
     stub:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def VERSION = '1.0' // WARN: Python script with no version control. This would be v1.0 of this script.
     """
     touch ${prefix}_${tool}_species_kegg_modules_comp.tsv
 

--- a/workflows/biosiftr.nf
+++ b/workflows/biosiftr.nf
@@ -35,7 +35,7 @@ include { POSTPROC_INTEGRATOR as INTEGRA_TAXO      } from '../modules/local/post
 include { POSTPROC_INTEGRATOR as INTEGRA_KO        } from '../modules/local/postproc/integrator'
 include { POSTPROC_INTEGRATOR as INTEGRA_PFAM      } from '../modules/local/postproc/integrator'
 include { POSTPROC_INTEGRATOR as INTEGRA_MODU      } from '../modules/local/postproc/integrator'
-include { DRAM_DISTILL            } from '../modules/local/dram/distill'
+include { DRAM_DISTILL                             } from '../modules/local/dram/distill'
 
 include { POSTPROC_INTEGRATOR as BWA_INT_TAXO      } from '../modules/local/postproc/integrator'
 include { POSTPROC_INTEGRATOR as BWA_INT_KO        } from '../modules/local/postproc/integrator'
@@ -99,7 +99,7 @@ workflow BIOSIFTR {
             return tuple(meta + [single_end: false], reads)
         }
     }
-    ch_reads = Channel.fromSamplesheet("input").map(groupReads)// [ meta, [raw_reads] ]
+    ch_reads = Channel.fromSamplesheet("input").map(groupReads) // [ meta, [raw_reads] ]
 
     // ---- PREPROCESSING: Trimming, decontamination, and post-treatment qc ---- //
     FASTP(ch_reads, [], [], [], [])
@@ -172,11 +172,21 @@ workflow BIOSIFTR {
     }
 
     if (params.run_dram) {
-        SM_DRAM(SM_FUNC.out.dram_spec, 'sm', 'species')
+        SM_DRAM(
+            SM_FUNC.out.dram_spec,
+            file(params.reference_dbs, checkIfExists: true),
+            'sm',
+            'species',
+        )
         ch_versions = ch_versions.mix(SM_DRAM.out.versions.first())
 
         ch_dram_community = SM_FUNC.out.dram_comm.collectFile(name: 'dram_community.tsv', newLine: true) { it[1] }.map { dram_summary -> [[id: 'integrated'], dram_summary] }
-        DRAM_DISTILL(ch_dram_community, 'sm', 'community')
+        DRAM_DISTILL(
+            ch_dram_community,
+            file(params.reference_dbs, checkIfExists: true),
+            'sm',
+            'community',
+        )
         ch_versions = ch_versions.mix(DRAM_DISTILL.out.versions.first())
     }
 
@@ -215,10 +225,11 @@ workflow BIOSIFTR {
 
         // Mapping reads and filtering positive genomes according with mapping coverage threshold
         POSTPROC_SOURMASHTAXO.out.sm_taxo
-            .map{ meta, taxo_file ->
+            .map { meta, taxo_file ->
                 def species_richness = taxo_file.countLines()
                 return tuple(meta, species_richness)
-            }.set {
+            }
+            .set {
                 species_richness_ch
             }
 
@@ -245,11 +256,21 @@ workflow BIOSIFTR {
         }
 
         if (params.run_dram) {
-            BWA_DRAM(BWA_FUNC.out.dram_spec, 'bwa', 'species')
+            BWA_DRAM(
+                BWA_FUNC.out.dram_spec,
+                file(params.reference_dbs, checkIfExists: true),
+                'bwa',
+                'species',
+            )
             ch_versions = ch_versions.mix(BWA_DRAM.out.versions.first())
 
             ch_bwa_dram_community = BWA_FUNC.out.dram_comm.collectFile(name: 'dram_community.tsv', newLine: true) { it[1] }.map { dram_summary -> [[id: 'integrated'], dram_summary] }
-            BWA_INT_DRAM(ch_bwa_dram_community, 'bwa', 'community')
+            BWA_INT_DRAM(
+                ch_bwa_dram_community,
+                file(params.reference_dbs, checkIfExists: true),
+                'bwa',
+                'community',
+            )
             ch_versions = ch_versions.mix(BWA_INT_DRAM.out.versions.first())
         }
 

--- a/workflows/biosiftr.nf
+++ b/workflows/biosiftr.nf
@@ -174,7 +174,7 @@ workflow BIOSIFTR {
     if (params.run_dram) {
         SM_DRAM(
             SM_FUNC.out.dram_spec,
-            file(params.reference_dbs, checkIfExists: true),
+            file("${params.reference_dbs}/dram_dbs", checkIfExists: true),
             'sm',
             'species',
         )
@@ -183,7 +183,7 @@ workflow BIOSIFTR {
         ch_dram_community = SM_FUNC.out.dram_comm.collectFile(name: 'dram_community.tsv', newLine: true) { it[1] }.map { dram_summary -> [[id: 'integrated'], dram_summary] }
         DRAM_DISTILL(
             ch_dram_community,
-            file(params.reference_dbs, checkIfExists: true),
+            file("${params.reference_dbs}/dram_dbs", checkIfExists: true),
             'sm',
             'community',
         )
@@ -258,7 +258,7 @@ workflow BIOSIFTR {
         if (params.run_dram) {
             BWA_DRAM(
                 BWA_FUNC.out.dram_spec,
-                file(params.reference_dbs, checkIfExists: true),
+                file("${params.reference_dbs}/dram_dbs", checkIfExists: true),
                 'bwa',
                 'species',
             )
@@ -267,7 +267,7 @@ workflow BIOSIFTR {
             ch_bwa_dram_community = BWA_FUNC.out.dram_comm.collectFile(name: 'dram_community.tsv', newLine: true) { it[1] }.map { dram_summary -> [[id: 'integrated'], dram_summary] }
             BWA_INT_DRAM(
                 ch_bwa_dram_community,
-                file(params.reference_dbs, checkIfExists: true),
+                file("${params.reference_dbs}/dram_dbs", checkIfExists: true),
                 'bwa',
                 'community',
             )


### PR DESCRIPTION
DRAM was using a paramter to mount the db, but this is not working in GCP as it doesn't consider the db a "file" as it's just a string. I've changed that and I added the db as an input (type path). This should fix that... let's see

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/biosiftr/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
