### PR TITLE
Fix some versions naming issues and removed redudant cat on awk command

### DIFF
--- a/modules/local/kegg/completeness.nf
+++ b/modules/local/kegg/completeness.nf
@@ -7,7 +7,7 @@ process KEGG_COMPLETENESS {
     input:
     tuple val(meta), path(kos_table)
     val(tool)
-    
+
     output:
     tuple val(meta), path("*_community_kegg_modules_comp.tsv"), emit: kegg_comp
     path "versions.yml"                                       , emit: versions
@@ -28,13 +28,17 @@ process KEGG_COMPLETENESS {
         -o result
 
     echo "Formatting output"
-    cat result.summary.kegg_pathways.tsv | awk -v prefix=${prefix} -v tool=${tool} -F'\\t' 'NR==1 {print "module\\t" prefix "_" tool; next} {print \$1 "|" \$3 "\\t" \$2}' result.summary.kegg_pathways.tsv > ${prefix}_${tool}_community_kegg_modules_comp.tsv
+    awk -v prefix=${prefix} \\
+        -v tool=${tool} \\
+        -F'\\t' \\
+        'NR==1 {print "module\\t" prefix "_" tool; next} {print \$1 "|" \$3 "\\t" \$2}' \\
+        result.summary.kegg_pathways.tsv > ${prefix}_${tool}_community_kegg_modules_comp.tsv
 
     echo "Reformatted output done"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        kegg_comm: $VERSION
+        kegg-pathways-completeness: $VERSION
     END_VERSIONS
     """
 
@@ -47,7 +51,7 @@ process KEGG_COMPLETENESS {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        kegg_comm: $VERSION
+        kegg-pathways-completeness: $VERSION
     END_VERSIONS
     """
 }

--- a/modules/local/kegg/species.nf
+++ b/modules/local/kegg/species.nf
@@ -22,7 +22,6 @@ process KEGG_SPECIES {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.0' // WARN: Python script with no version control. This would be v1.0 of this script.
     """
     species2pathways.py \\
         --kegg_comp_db $kegg_db \\
@@ -33,20 +32,21 @@ process KEGG_SPECIES {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        kegg_sp: $VERSION
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+        biopython: \$(python -c "import importlib.metadata; print(importlib.metadata.version('biopython'))")
     END_VERSIONS
     """
 
     stub:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.0' // WARN: Python script with no version control. This would be v1.0 of this script.
     """
     touch ${prefix}_${tool}_species_kegg_modules_comp.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        kegg_sp: $VERSION
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+        biopython: \$(python -c "import importlib.metadata; print(importlib.metadata.version('biopython'))")
     END_VERSIONS
     """
 }

--- a/modules/local/postproc/bam2cov.nf
+++ b/modules/local/postproc/bam2cov.nf
@@ -19,7 +19,6 @@ process POSTPROC_BAM2COV {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.1' // WARN: Python script with no version control. This would be v1.1 of this script.
     """
     bam2cov_filt.py \\
         --bwa_bam $bam \\
@@ -29,20 +28,21 @@ process POSTPROC_BAM2COV {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        postproc: $VERSION
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+        pysam: \$(python3 -c "import pkg_resources; print(pkg_resources.get_distribution('pysam').version)")
     END_VERSIONS
     """
 
     stub:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.0'
     """
     touch ${prefix}_u_relab.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        postproc: $VERSION
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+        pysam: \$(python3 -c "import pkg_resources; print(pkg_resources.get_distribution('pysam').version)")
     END_VERSIONS
     """
 }

--- a/modules/local/postproc/bwataxo.nf
+++ b/modules/local/postproc/bwataxo.nf
@@ -20,7 +20,6 @@ process POSTPROC_BWATAXO {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.0' // WARN: Python script with no version control. This would be v1.0 of this script.
     """
     bwa_genome2species.py \\
         --genomes_relab $cov_file  \\
@@ -30,20 +29,21 @@ process POSTPROC_BWATAXO {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        postproc: $VERSION
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+        biopython: \$(python -c "import importlib.metadata; print(importlib.metadata.version('biopython'))")
     END_VERSIONS
     """
 
     stub:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.0'
     """
     touch ${prefix}_bwa_species.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        postproc: $VERSION
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+        biopython: \$(python -c "import importlib.metadata; print(importlib.metadata.version('biopython'))")
     END_VERSIONS
     """
 }

--- a/modules/local/postproc/functionspred.nf
+++ b/modules/local/postproc/functionspred.nf
@@ -30,7 +30,6 @@ process POSTPROC_FUNCTIONSPRED {
     script:
     def dram_arg = (run_dram) ? "--dram_out" : ""
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.0' // WARN: Python script with no version control. This would be v1.0 of this script.
     """
     species2functions.py \\
         --pangenome_db $pangenome_db \\
@@ -42,7 +41,8 @@ process POSTPROC_FUNCTIONSPRED {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        postproc: $VERSION
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+        biopython: \$(python -c "import importlib.metadata; print(importlib.metadata.version('biopython'))")
     END_VERSIONS
     """
 
@@ -59,7 +59,8 @@ process POSTPROC_FUNCTIONSPRED {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        postproc: $VERSION
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+        biopython: \$(python -c "import importlib.metadata; print(importlib.metadata.version('biopython'))")
     END_VERSIONS
     """
 }

--- a/modules/local/postproc/integrator.nf
+++ b/modules/local/postproc/integrator.nf
@@ -18,7 +18,6 @@ process POSTPROC_INTEGRATOR {
 
     script:
     def args = task.ext.args ?: ''
-    def VERSION = '1.0' // WARN: Python script with no version control. This would be v1.0 of this script.
     """
     matrix_integrator.py \\
         --input ${files_list.join(' ')} \\
@@ -27,19 +26,20 @@ process POSTPROC_INTEGRATOR {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        postproc: $VERSION
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+        biopython: \$(python -c "import importlib.metadata; print(importlib.metadata.version('biopython'))")
     END_VERSIONS
     """
 
     stub:
     def args = task.ext.args ?: ''
-    def VERSION = '1.0'
     """
     touch ${annot_type}_matrix.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        postproc: $VERSION
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+        biopython: \$(python -c "import importlib.metadata; print(importlib.metadata.version('biopython'))")
     END_VERSIONS
     """
 }

--- a/modules/local/postproc/sourmashtaxo.nf
+++ b/modules/local/postproc/sourmashtaxo.nf
@@ -20,7 +20,6 @@ process POSTPROC_SOURMASHTAXO {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.0' // WARN: Python script with no version control. This would be v1.0 of this script. 
     """
     sm_genome2species.py \\
         --sm_csv $gather_result_csv \\
@@ -30,20 +29,21 @@ process POSTPROC_SOURMASHTAXO {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        postproc: $VERSION
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+        biopython: \$(python -c "import importlib.metadata; print(importlib.metadata.version('biopython'))")
     END_VERSIONS
     """
 
     stub:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.0'
     """
     touch ${prefix}_sm_species.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        postproc: $VERSION
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+        biopython: \$(python -c "import importlib.metadata; print(importlib.metadata.version('biopython'))")
     END_VERSIONS
     """
 }

--- a/workflows/download_references.nf
+++ b/workflows/download_references.nf
@@ -1,0 +1,5 @@
+include { DOWNLOAD_REFERENCES } from '../subworkflows/download_references'
+
+workflow {
+    DOWNLOAD_REFERENCES(params.biome, params.run_bwa)
+}


### PR DESCRIPTION
Some scripts where priting the version of the subworkflow name or module instead of the script (or python modules) they were using (which is our team practice).

I'm having issues with kegg completness in the cloud.. I'm getting an 141 exit code which I think is related to a pipe issue. I remove a redudant file in the kegg completness module (in an awk command).

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/biosiftr/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
